### PR TITLE
もっとみるボタンのデザイン変更、レスポンシブ対応

### DIFF
--- a/css/body.css
+++ b/css/body.css
@@ -80,6 +80,89 @@ html{
   transition-duration: 0.9s;
 }
 
+
+/* view more ボタン */
+.more {
+  height: 10em;
+  position: relative;
+  text-align: center;
+  margin-top: -100px;
+  margin-bottom: 50px;
+}
+.view-more-button {
+  border: 2px solid slategrey;
+  border-radius: 100%;
+  width: 5rem;
+  height: 5rem;
+  margin: 0;
+  position: relative;
+  left: 47%;
+  bottom: 50%;
+  display: flex;
+  margin-right: -50%;
+  /* transform: translate(-50%, -50%);
+  background-color: #aac8ec;
+  transition: 0.7s; */
+}
+.view-more-button:hover {
+  /* left: -70px;
+  transition-property: left;
+  transition-duration: 100s; */
+  opacity: 0.3;
+  transition: 0.5s;
+}
+.hide-view-more-button {
+  display: none;
+}
+.angles{
+  width: 50%;
+  height: 50%;
+  position: relative;
+  left: 1.25rem;
+  top: 1.15rem;
+}
+.view-more-JPN{
+  display: none;
+  position: relative;
+  top: 10px;
+}
+/* Communityのページ */
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  border-spacing: 0;
+  font-size: 14px;
+}
+.table th {
+  width: 22%;
+  background: #aac8ec;
+  border: 1px solid #888482;
+  box-sizing: border-box;
+  padding: 15px;
+  vertical-align: middle;
+  font-weight: bold;
+  text-align: center;
+}
+.table td {
+  background: #fff;
+  border: 1px solid #888482;
+  box-sizing: border-box;
+  padding: 15px;
+  vertical-align: top;
+  text-align: left;
+}
+@media all and (max-width: 767px) {
+  .table th,
+  .table td {
+    display: block;
+    width: 100%;
+    border-bottom: none;
+  }
+  .table tr:last-child td:last-child {
+    border-bottom: 1px solid #888482;
+  }
+}
+
 @media screen and (max-width: 900px) {
   .introduction-card {
     width: 40%;
@@ -141,68 +224,43 @@ html{
     transition-duration: 0.9s;
   }
   
-}
-
-/* view more ボタン */
-.more {
-  height: 10em;
-  position: relative;
-  text-align: center;
-  margin-top: 20px;
-}
-.view-more-button {
-  width: 250px;
-  height: 50px;
-  margin: 0;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  margin-right: -50%;
-  transform: translate(-50%, -50%);
-  background-color: #aac8ec;
-  transition: 0.7s;
-}
-.view-more-button:hover {
-  opacity: 0.3;
-  transition: 0.5s;
-}
-.hide-view-more-button {
-  display: none;
-}
-
-/* Communityのページ */
-.table {
-  width: 100%;
-  border-collapse: collapse;
-  border-spacing: 0;
-  font-size: 14px;
-}
-.table th {
-  width: 22%;
-  background: #aac8ec;
-  border: 1px solid #888482;
-  box-sizing: border-box;
-  padding: 15px;
-  vertical-align: middle;
-  font-weight: bold;
-  text-align: center;
-}
-.table td {
-  background: #fff;
-  border: 1px solid #888482;
-  box-sizing: border-box;
-  padding: 15px;
-  vertical-align: top;
-  text-align: left;
-}
-@media all and (max-width: 767px) {
-  .table th,
-  .table td {
-    display: block;
-    width: 100%;
-    border-bottom: none;
+  .more {
+    height: 10em;
+    position: relative;
+    text-align: center;
+    margin-top: -100px;
+    margin-bottom: 50px;
   }
-  .table tr:last-child td:last-child {
-    border-bottom: 1px solid #888482;
+  .view-more-button {
+    border: 2px solid slategrey;
+    border-radius: 100%;
+    width: 10rem;
+    height: 10rem;
+    margin: 0;
+    position: relative;
+    left: 44%;
+    bottom: 50%;
+    display: flex;
+    margin-right: -50%;
+    /* transform: translate(-50%, -50%);
+    background-color: #aac8ec;
+    transition: 0.7s; */
+  }
+  .view-more-button:hover {
+    /* left: -70px;
+    transition-property: left;
+    transition-duration: 100s; */
+    opacity: 0.3;
+    transition: 0.5s;
+  }
+  .hide-view-more-button {
+    display: none;
+  }
+  .angles{
+    width: 50%;
+    height: 50%;
+    position: relative;
+    left: 2.4rem;
+    top: 2.2rem;
   }
 }

--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@
     href="https://fonts.googleapis.com/css2?family=Murecho&family=Supermercado+One&family=Zen+Kurenaido&display=swap"
     rel="stylesheet">
   <link rel="stylesheet" href="css/loading.css">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.4/css/all.css"
+        integrity="sha384-DyZ88mC6Up2uqS4h/KRgHuoeGwBcD4Ng9SiP4dIRy0EXTlnuz47vAwmeGwVChigm" crossorigin="anonymous">
 </head>
 
 <body>
@@ -64,7 +66,14 @@
     <div class="introduction-cards" id="introduction_box">
     </div>
     <div class="more">
-      <button class="view-more-button" id="ViewMoreButton" onclick="viewmore()">もっとみる</button>
+      <div>
+        <div class="view-more-button" id="ViewMoreButton" onclick="viewmore()">
+          <svg class="angles" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><!--! Font Awesome Pro 6.0.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path d="M169.4 278.6C175.6 284.9 183.8 288 192 288s16.38-3.125 22.62-9.375l160-160c12.5-12.5 12.5-32.75 0-45.25s-32.75-12.5-45.25 0L192 210.8L54.63 73.38c-12.5-12.5-32.75-12.5-45.25 0s-12.5 32.75 0 45.25L169.4 278.6zM329.4 265.4L192 402.8L54.63 265.4c-12.5-12.5-32.75-12.5-45.25 0s-12.5 32.75 0 45.25l160 160C175.6 476.9 183.8 480 192 480s16.38-3.125 22.62-9.375l160-160c12.5-12.5 12.5-32.75 0-45.25S341.9 252.9 329.4 265.4z"/></svg>
+          <p class="view-more-JPN">
+            もっとみる
+          </p>
+        </div>
+      </div>
     </div>
   </main>
   <!-- 00footer -->

--- a/js/body.js
+++ b/js/body.js
@@ -149,7 +149,6 @@ for (let i = 1; i < 24; i++) {
   introduction_box.insertAdjacentHTML("beforeend", introduction);
 }
 $(contents + ":nth-child(n + " + (show + 1) + ")").addClass("is-hidden");
-
 // for (let i = 1; i < 13; i++) {
 // let introduction =
 //   `<div class="introduction-card">`
@@ -167,7 +166,7 @@ $(contents + ":nth-child(n + " + (show + 1) + ")").addClass("is-hidden");
 // };
 
 // function viewmore() {
-//   ViewMoreButton.classList.add('hide-view-more-button');
+//   ViewMoreButton.classList.add('hide--more-button');
 //   for (let i = 13; i < 24; i++) {
 //     let introduction =
 //       `<div class="introduction-card">`


### PR DESCRIPTION
# やったこと
もっとみるのボタンのデザインを変更した。もっとみるボタンではなく、矢印のボタンにした。レスポンシブ対応もさせて、幅が狭くなるときにデザインが崩れないようにした。

<img width="1481" alt="スクリーンショット 2022-02-11 14 01 06" src="https://user-images.githubusercontent.com/94788880/153540127-5d5a2113-bc69-42c7-b186-572fc61be3b3.png">
<img width="1481" alt="スクリーンショット 2022-02-10 23 00 49" src="https://user-images.githubusercontent.com/94788880/153540136-0cc3a5dd-f53f-4970-ad77-2e7b2b96988b.png">

