### PR TITLE
Feature/#50 51 logo to jump and make main inner

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -49,19 +49,19 @@
         <li ><a href="https://line.me/R/ti/p/@651htnqp?from=page">CONTACT</a></li>
       </ul>
     </div>
-
-    <h2 class="page-title">About</h2>
-
-    <div>
-      私たちはPOSSE2です。
+    <div class="main-inner">
+      <h2 class="page-title">About</h2>
+      <div class="about-contents">
+        <p>私たちはPOSSE2です。</p>
+      </div>
     </div>
-  </main>
+    </main>
     <!-- 00footer -->
     <footer class="footer wapper">
       <ul class="footer__nav">
         <li><a href="https://www.instagram.com/posse_programming
-                    " target="_blank">INSTAGRAM</a></li>
-        <li><a href="https://twitter.com/posse_program
+          " target="_blank">INSTAGRAM</a></li>
+          <li><a href="https://twitter.com/posse_program
                       " target="_blank">TWITTER</a></li>
         <li><a href="https://www.facebook.com/HarborS-110032910423433" target="_blank">FACEBOOK</a></li>
       </ul>

--- a/about/index.html
+++ b/about/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>About us</title>
+  <title>About us | POSSE2</title>
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css//header.css">
   <link rel="stylesheet" href="../css/body.css">

--- a/about/index.html
+++ b/about/index.html
@@ -19,8 +19,10 @@
     <div class="header-inner">
       <div class="header-content">
         <div class="header-logo">
-          <img
-          src="../picture/posse2ロゴ.png" alt="POSSEのロゴ">
+          <a href="../index.html">
+            <img
+            src="../picture/posse2ロゴ.png" alt="POSSEのロゴ">
+          </a>
         </div>
       </div>
       <!-- <div>

--- a/community/index.html
+++ b/community/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>About us</title>
+  <title>Community | POSSE2</title>
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css//header.css">
   <link rel="stylesheet" href="../css/body.css">

--- a/community/index.html
+++ b/community/index.html
@@ -49,37 +49,41 @@
         <li ><a href="https://line.me/R/ti/p/@651htnqp?from=page">CONTACT</a></li>
       </ul>
     </div>
+    <div class="main-inner">
 
-    <h2 class="page-title">Community</h2>
+      <h2 class="page-title">Community</h2>
+      <div class="community-contents">
 
-    <div  >
+        <div>
+          <table class="table">
+            <tr>
+              <th>名称</th>
+              <td>POSSE2</td>
+            </tr>
+            <tr>
+              <th>拠点</th>
+              <td>
+                HarborS表参道<br>
+                〒107-0062 東京都港区南青山３丁目１５−９ MINOWA表参道 3階
+              </td>
+            </tr>
+            <tr>
+              <th>設立</th>
+              <td>2021年11月</td>
+            </tr>
+            <tr>
+              <th>メンバー数</th>
+              <td>23人</td>
+            </tr>
+          </table>
+        </div>
+        
+        <div>
+          <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d202.59359075858026!2d139.71519223701566!3d35.66475141289963!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x60188b8a9122f1cd%3A0xcfe4aad9a0735cb8!2z44OP44O844OQ44O844K66KGo5Y-C6YGT!5e0!3m2!1sja!2sjp!4v1643807286074!5m2!1sja!2sjp" width="100%" height="450" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
+        </div>
+      </div>
 
-  <table class="table">
-    <tr>
-      <th>名称</th>
-      <td>POSSE2</td>
-    </tr>
-    <tr>
-      <th>拠点</th>
-      <td>
-        HarborS表参道<br>
-        〒107-0062 東京都港区南青山３丁目１５−９ MINOWA表参道 3階
-      </td>
-    </tr>
-    <tr>
-      <th>設立</th>
-      <td>2021年11月</td>
-    </tr>
-    <tr>
-      <th>メンバー数</th>
-      <td>23人</td>
-    </tr>
-  </table>
-
-
-      <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d202.59359075858026!2d139.71519223701566!3d35.66475141289963!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x60188b8a9122f1cd%3A0xcfe4aad9a0735cb8!2z44OP44O844OQ44O844K66KGo5Y-C6YGT!5e0!3m2!1sja!2sjp!4v1643807286074!5m2!1sja!2sjp" width="100%" height="450" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
     </div>
-
   </main>
     <!-- 00footer -->
     <footer class="footer wapper">

--- a/community/index.html
+++ b/community/index.html
@@ -19,8 +19,10 @@
     <div class="header-inner">
       <div class="header-content">
         <div class="header-logo">
-          <img
-          src="../picture/posse2ロゴ.png" alt="POSSEのロゴ">
+          <a href="../index.html">
+            <img
+            src="../picture/posse2ロゴ.png" alt="POSSEのロゴ">
+          </a>
         </div>
       </div>
       <!-- <div>

--- a/css/body.css
+++ b/css/body.css
@@ -6,6 +6,10 @@ html {
   padding: 0px 40px;
 }
 
+.main-inner{
+  padding-top: 125px;
+}
+
 .page-title {
   color: black;
   font-size: 25px;
@@ -106,8 +110,17 @@ html {
   top: 1.15rem;
   color: #333;
 }
-
+/* Aboutのページ */
+.about-contents{
+  margin: 60px 0px;
+}
+.about-contents p{
+  font-size: 15px;
+} 
 /* Communityのページ */
+.community-contents div{
+  margin: 60px 0px;
+}
 .table {
   width: 100%;
   border-collapse: collapse;

--- a/css/header.css
+++ b/css/header.css
@@ -12,7 +12,7 @@
   z-index: 1100;
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
 }
- .header-burger-ver{
+.header-burger-ver{
   width: 100%;
   height: 65px;
   background-color: #86b1e6;

--- a/index.html
+++ b/index.html
@@ -73,16 +73,18 @@
     </div>
     
     <!-- つよちゃんbody gannba-->
-    <h2 class="page-title">MEMBERS</h2>
-    <div class="introduction-cards" id="introduction_box">
-    </div>
-    <div class="more">
-      <div>
-        <div class="view-more-button" id="ViewMoreButton" onclick="viewmore()">
-          <svg class="angles" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><!--! Font Awesome Pro 6.0.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path d="M169.4 278.6C175.6 284.9 183.8 288 192 288s16.38-3.125 22.62-9.375l160-160c12.5-12.5 12.5-32.75 0-45.25s-32.75-12.5-45.25 0L192 210.8L54.63 73.38c-12.5-12.5-32.75-12.5-45.25 0s-12.5 32.75 0 45.25L169.4 278.6zM329.4 265.4L192 402.8L54.63 265.4c-12.5-12.5-32.75-12.5-45.25 0s-12.5 32.75 0 45.25l160 160C175.6 476.9 183.8 480 192 480s16.38-3.125 22.62-9.375l160-160c12.5-12.5 12.5-32.75 0-45.25S341.9 252.9 329.4 265.4z"/></svg>
+    <div class="main-inner">
+      <h2 class="page-title">MEMBERS</h2>
+      <div class="introduction-cards" id="introduction_box">
+      </div>
+      <div class="more">
+        <div>
+          <div class="view-more-button" id="ViewMoreButton" onclick="viewmore()">
+            <svg class="angles" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><!--! Font Awesome Pro 6.0.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path d="M169.4 278.6C175.6 284.9 183.8 288 192 288s16.38-3.125 22.62-9.375l160-160c12.5-12.5 12.5-32.75 0-45.25s-32.75-12.5-45.25 0L192 210.8L54.63 73.38c-12.5-12.5-32.75-12.5-45.25 0s-12.5 32.75 0 45.25L169.4 278.6zM329.4 265.4L192 402.8L54.63 265.4c-12.5-12.5-32.75-12.5-45.25 0s-12.5 32.75 0 45.25l160 160C175.6 476.9 183.8 480 192 480s16.38-3.125 22.62-9.375l160-160c12.5-12.5 12.5-32.75 0-45.25S341.9 252.9 329.4 265.4z"/></svg>
+          </div>
         </div>
       </div>
-    </div>
+  </div>
   </main>
   <!-- 00footer -->
   <footer class="footer">
@@ -91,11 +93,11 @@
         <img src="picture/iconmonstr-instagram-11.svg" alt="">
         <a href="https://www.instagram.com/posse_programming
           " target="_blank">INSTAGRAM</a>
-      </li>
+        </li>
       <li class="footer-twitter">
         <img src="picture/iconmonstr-twitter-1.svg" alt="">
         <a href="https://twitter.com/posse_program
-            " target="_blank">TWITTER</a>
+        " target="_blank">TWITTER</a>
       </li>
       <li class="footer-facebook">
         <img src="picture/iconmonstr-facebook-6.svg" alt="">

--- a/index.html
+++ b/index.html
@@ -40,8 +40,9 @@
     <div class="header-inner">
       <div class="header-content">
         <div class="header-logo">
-          <img
-          src="./picture/posse2ロゴ.png" alt="POSSEのロゴ">
+          <a href="./index.html">
+            <img src="./picture/posse2ロゴ.png" alt="POSSEのロゴ">
+          </a>
         </div>
       </div>
       <!-- <div>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>moshamoshaC</title>
+  <title>Members | POSSE2</title>
   <link rel="stylesheet" href="./css/reset.css" />
   <link rel="stylesheet" href="./css/header.css" />
   <link rel="stylesheet" href="./css/body.css" />

--- a/js/header.js
+++ b/js/header.js
@@ -17,6 +17,8 @@ function hamburger() {
   document.getElementById('popupCover').classList.toggle('black-out');
 
   header.classList.toggle('header')
+
+  
 }
 
 document.getElementById('hamburger').addEventListener('click' , function () {

--- a/js/transition.js
+++ b/js/transition.js
@@ -145,7 +145,7 @@ var contents = `
   url["id"]
 }">
     <img
-    src="https://posse.anti-pattern.co.jp/img/posseLogo.png" alt="POSSEのロゴ"/>
+    src="../picture/posse2ロゴ.png" alt="POSSEのロゴ"/>
     </a>
     <span class="member-title">
     member${url["id"]}

--- a/transition/index.html
+++ b/transition/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <title>Member | POSSE2</title>
     <link rel="stylesheet" href="../css/transition.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## やったこと
#50 と#51 に対応しました。

### #50 について
issueに書いてあるとおりに対応しました。

### #51 について
issueに書いてあることに加えて、aboutとcommunityのページはコンテンツについても余白を作った。
#### ビフォー
![image](https://user-images.githubusercontent.com/94669039/153719149-2bcd858e-4098-4e1b-9bc3-4492342f4b5c.png)
   ↓
#### アフター
![image](https://user-images.githubusercontent.com/94669039/153719170-9c488416-9f0a-4124-b946-bde303692559.png)

### その他
ついでに、各ページのページタイトルを xxxx | POSSE2 という形式に変えておきました。